### PR TITLE
docs: align AGENTS.md + CODE_STANDARDS.md with ngdpbase patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 project_state: "template"
-last_updated: "2025-12-21"
+last_updated: "2026-05-23"
 agent_priority_level: "medium"
 blockers: []
 requires_human_review: ["major architectural changes", "security policy modifications", "deployment to production"]
@@ -58,6 +58,69 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for project structure, technology stack
 ## Coding Standards
 
 See [CODE_STANDARDS.md](./CODE_STANDARDS.md) for naming conventions, formatting, linting, testing, and commit message format.
+
+## Behavioral Principles
+
+These four principles reduce common LLM coding mistakes. They bias toward caution over speed; for trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop, name what's confusing, ask.
+
+This applies to ambiguous scope, not every step — `agent_autonomy_level: high` still holds for clearly-defined work.
+
+### 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ship the smallest coherent slice. Ask before bundling adjacent work into the current change.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that your changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with a verify-step per item. Strong success criteria let you loop independently; weak criteria ("make it work") require constant clarification.
+
+These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Project Constraints
 

--- a/CODE_STANDARDS.md
+++ b/CODE_STANDARDS.md
@@ -15,7 +15,7 @@ Related documents:
 - **No secrets in Git** - NEVER put unencrypted secrets in Git or other CMS systems.
 - **GitHub CLI** - Primary method for interacting with GitHub.
 - **Think first** - Present options before implementing. On larger objectives, present a phased plan.
-- **Markdown style** - Use **bold** at start of list items. Use bullet points, not numbered lists (section headers like `## Step 1` are fine).
+- **Markdown style** - Use bullet points, not numbered lists for content (section headers like `## Step 1` are fine). No bold text as a heading or pseudo-heading — see Markdownlint MD036 below.
 
 ## Language & Environment
 
@@ -114,7 +114,7 @@ npm run lint:md       # Check all markdown files
 npm run lint:md:fix   # Auto-fix markdown issues (note: MD036 requires manual fix)
 ```
 
-**Heading vs Bold Text:**
+#### Heading vs Bold Text
 
 ```markdown
 <!-- Bad - bold text used as heading -->


### PR DESCRIPTION
## Summary

- Brings forward the four generic **Behavioral Principles** (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) developed and stress-tested in the ngdpbase reference project.
- Fixes two MD036 self-violations in `CODE_STANDARDS.md` — the rule that forbids bold-as-heading was itself written with bold pseudo-headings, and a Guiding Principle endorsed a pattern that contradicted the rule.
- Bumps `AGENTS.md` frontmatter `last_updated` from the stale 2025-12-21 to 2026-05-23.

## Changes

- `AGENTS.md`: new `## Behavioral Principles` section between Coding Standards and Project Constraints; `last_updated` frontmatter refreshed.
- `CODE_STANDARDS.md`: Guiding Principle reworded to remove the "Use **bold** at start of list items" line that directly contradicted MD036; `**Heading vs Bold Text:**` promoted to `#### Heading vs Bold Text`.

## What this PR deliberately does NOT bring over

The intent is to keep the template **generic**. The following ngdpbase-specific concepts were considered and excluded:

- Project-specific class names (`WikiContext`, `WikiDocument`)
- Project-specific URL conventions (`/view/` vs `/wiki/` route migration)
- Project-specific tooling (`./server.sh`, `FAST_STORAGE`/`SLOW_STORAGE`, `jimstest` paths)
- Project-specific config (`config/app-default-config.json` permission catalog)
- The strict session-commit-on-every-commit workflow (template projects may not need a `project_log.md` at all)

## Test Plan

- [x] `npm run lint` — Husky pre-commit hook ran clean on both commits
- [ ] `npm run typecheck` — no `.ts` files touched; skipped
- [ ] `npm run test` — no `.ts` files touched; skipped
- [ ] `npm run build` — no `.ts` files touched; skipped

## Checklist

- [x] Code follows [CODE_STANDARDS.md](../CODE_STANDARDS.md)
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow conventional format
- [x] AGENTS.md updated (this IS the AGENTS.md update)