### PR TITLE
docs: strict MD036 sweep — strip decorative bold-prefix from list items

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -8,18 +8,18 @@ MCP (Model Context Protocol) allows Claude to quickly access project context thr
 
 ## Files
 
-- **`mcp.json`** - MCP server configuration (currently empty, ready for extension)
-- **`commands/`** - Directory containing command definitions
+- `mcp.json` - MCP server configuration (currently empty, ready for extension)
+- `commands/` - Directory containing command definitions
 
 ## Available Commands
 
 ### `/context`
 
-**File:** `commands/context.md`
+File: `commands/context.md`
 
 Reads and summarizes the AGENTS.md file to get the current project state.
 
-**What it shows:**
+#### What it shows
 
 - Project name, description, and goals
 - Current progress and status
@@ -27,9 +27,9 @@ Reads and summarizes the AGENTS.md file to get the current project state.
 - Known blockers or issues
 - TODO items and next priorities
 
-**When to use:** At the start of each session to understand what's been done and what needs attention.
+When to use: At the start of each session to understand what's been done and what needs attention.
 
-**Example usage:**
+#### Example usage
 
 ```
 /context
@@ -37,20 +37,20 @@ Reads and summarizes the AGENTS.md file to get the current project state.
 
 ### `/check-todos`
 
-**File:** `commands/check-todos.md`
+File: `commands/check-todos.md`
 
 Displays actionable work items organized by priority level.
 
-**What it shows:**
+#### What it shows
 
 - High priority tasks (should start here)
 - Medium priority tasks (important but not blocking)
 - Low priority tasks (nice to have)
 - Known blockers preventing progress
 
-**When to use:** To decide what to work on in the current session and focus effort appropriately.
+When to use: To decide what to work on in the current session and focus effort appropriately.
 
-**Example usage:**
+#### Example usage
 
 ```
 /check-todos
@@ -58,11 +58,11 @@ Displays actionable work items organized by priority level.
 
 ### `/update-agents`
 
-**File:** `commands/update-agents.md`
+File: `commands/update-agents.md`
 
 Reminds you to update AGENTS.md with your session's progress.
 
-**What it helps document:**
+#### What it helps document
 
 - Work completed this session
 - Files modified
@@ -70,9 +70,9 @@ Reminds you to update AGENTS.md with your session's progress.
 - New blockers discovered
 - Recommended next steps
 
-**When to use:** At the end of a session to document progress for the next agent or human contributor.
+When to use: At the end of a session to document progress for the next agent or human contributor.
 
-**Example usage:**
+#### Example usage
 
 ```
 /update-agents
@@ -80,10 +80,10 @@ Reminds you to update AGENTS.md with your session's progress.
 
 ## Typical Workflow
 
-1. **Start session:** Use `/context` to understand project state
-2. **Check priorities:** Use `/check-todos` to pick what to work on
-3. **Work on tasks:** Complete your assigned work, following CODE_STANDARDS.md
-4. **End session:** Use `/update-agents` to document progress in AGENTS.md
+1. Start session: Use `/context` to understand project state
+2. Check priorities: Use `/check-todos` to pick what to work on
+3. Work on tasks: Complete your assigned work, following CODE_STANDARDS.md
+4. End session: Use `/update-agents` to document progress in AGENTS.md
 
 ## Extending MCP
 

--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -34,23 +34,23 @@ git fetch template
 
 Present these options:
 
-- **Cherry-pick** — pick specific commits from the template (show the commit list and ask which ones)
-- **Merge** — merge all template changes into a new branch (`chore/template-sync`)
-- **File copy** — copy specific files from the template branch without merge history (using `git checkout template/master -- <file>`)
-- **Cancel** — do nothing
+- Cherry-pick — pick specific commits from the template (show the commit list and ask which ones)
+- Merge — merge all template changes into a new branch (`chore/template-sync`)
+- File copy — copy specific files from the template branch without merge history (using `git checkout template/master -- <file>`)
+- Cancel — do nothing
 
 ### Step 5: Apply changes
 
 Based on the user's choice:
 
-**Cherry-pick:**
+#### Cherry-pick
 
 - Create branch: `git checkout -b chore/template-sync`
 - Cherry-pick the selected commits: `git cherry-pick <hash> --no-commit`
 - Show the result with `git status` and `git diff --stat`
 - Let the user review before committing
 
-**Merge:**
+#### Merge
 
 - Create branch: `git checkout -b chore/template-sync`
 - Run: `git merge template/master --allow-unrelated-histories --no-commit`
@@ -58,7 +58,7 @@ Based on the user's choice:
 - Show the result with `git status` and `git diff --stat`
 - Let the user review before committing
 
-**File copy:**
+#### File copy
 
 - Create branch: `git checkout -b chore/template-sync`
 - For each requested file: `git checkout template/master -- <file>`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,5 +23,5 @@ labels: bug
 
 ## Environment
 
-- **Node version**: <!-- e.g. 20.x -->
-- **OS**: <!-- e.g. macOS 15, Ubuntu 24.04 -->
+- Node version: <!-- e.g. 20.x -->
+- OS: <!-- e.g. macOS 15, Ubuntu 24.04 -->

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 This directory contains CI/CD pipeline definitions for automated testing, linting, security checks, and deployments.
 
-**Related documentation:**
+#### Related documentation
 
 - [SECURITY.md](../../SECURITY.md) - Secret management and security best practices
 - [CODE_STANDARDS.md](../../CODE_STANDARDS.md) - Code quality standards that CI/CD enforces
@@ -12,35 +12,35 @@ This directory contains CI/CD pipeline definitions for automated testing, lintin
 
 ### `ci.yml` - Continuous Integration
 
-**Triggered on:** Push to `master` or `develop`, Pull Requests
+Triggered on: Push to `master` or `develop`, Pull Requests
 
-**What it does:**
+#### What it does
 
-1. **Lint and Test** (Node 20.x and 22.x)
+1. Lint and Test (Node 20.x and 22.x)
    - Installs dependencies
    - Runs ESLint for code quality
    - Type-checks with TypeScript
    - Runs test suite
    - Generates coverage reports
 
-2. **Security Audit**
+2. Security Audit
    - Audits npm dependencies for vulnerabilities
    - Checks for known security issues
    - Runs in parallel with other checks
 
-3. **Build**
+3. Build
    - Builds the TypeScript project
    - Uploads build artifacts for verification
 
-**When it passes:** All code quality checks pass, tests pass, builds successfully
+When it passes: All code quality checks pass, tests pass, builds successfully
 
-**When it fails:** Will block PR merges and notify on push
+When it fails: Will block PR merges and notify on push
 
 ### `deploy.yml` - Deployment Pipeline
 
-**Triggered on:** Push to `master` branch or manual workflow_dispatch
+Triggered on: Push to `master` branch or manual workflow_dispatch
 
-**What it does:**
+#### What it does
 
 1. Sets up Node.js environment
 2. Installs dependencies
@@ -48,7 +48,7 @@ This directory contains CI/CD pipeline definitions for automated testing, lintin
 4. Builds project
 5. Placeholder for deployment steps (configure for your platform)
 
-**Deployment Targets (configure as needed):**
+#### Deployment Targets (configure as needed)
 
 - AWS Lambda, EC2, or Elastic Beanstalk
 - Heroku
@@ -58,7 +58,7 @@ This directory contains CI/CD pipeline definitions for automated testing, lintin
 - Kubernetes clusters
 - Docker registries
 
-**How to configure:** Edit the deployment steps section in `deploy.yml` for your platform
+How to configure: Edit the deployment steps section in `deploy.yml` for your platform
 
 ## Setting Up Secrets
 
@@ -74,7 +74,7 @@ Quick setup:
    - `DOCKER_REGISTRY_TOKEN`
    - `DATABASE_URL` (for migrations)
 
-**Example usage in workflow:**
+#### Example usage in workflow
 
 ```yaml
 - name: Deploy to Heroku

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@ See YAML frontmatter above for current project state.
 
 ### Core Documentation (Single Source of Truth)
 
-- [README.md](./README.md) - **Single Source of Truth:** Project overview, setup, and quick start
-- [CODE_STANDARDS.md](./CODE_STANDARDS.md) - **Single Source of Truth:** Guiding principles, naming, formatting, linting, testing, commits
-- [ARCHITECTURE.md](./ARCHITECTURE.md) - **Single Source of Truth:** Project structure, directory conventions, technology stack
-- [SECURITY.md](./SECURITY.md) - **Single Source of Truth:** Secret management, dependency security, authentication, encryption
-- [CONTRIBUTING.md](./CONTRIBUTING.md) - **Single Source of Truth:** Development workflow, branching strategy, pull request process
-- [project_log.md](docs/project_log.md) - **Single Source of Truth:** Historical record of work done, next steps, session tracking
+- [README.md](./README.md) - Single Source of Truth: Project overview, setup, and quick start
+- [CODE_STANDARDS.md](./CODE_STANDARDS.md) - Single Source of Truth: Guiding principles, naming, formatting, linting, testing, commits
+- [ARCHITECTURE.md](./ARCHITECTURE.md) - Single Source of Truth: Project structure, directory conventions, technology stack
+- [SECURITY.md](./SECURITY.md) - Single Source of Truth: Secret management, dependency security, authentication, encryption
+- [CONTRIBUTING.md](./CONTRIBUTING.md) - Single Source of Truth: Development workflow, branching strategy, pull request process
+- [project_log.md](docs/project_log.md) - Single Source of Truth: Historical record of work done, next steps, session tracking
 
 ### Auxiliary Documentation
 
@@ -181,9 +181,9 @@ See [project_log.md](docs/project_log.md) for the required format, historical wo
 
 ### Agent Behavior Rules
 
-- **Eagerness** - Do not jump into implementation or change files unless clearly instructed. When intent is ambiguous, default to research and recommendations rather than action. Only proceed with edits when the user explicitly requests them.
-- **No speculation** - Never speculate about code you have not opened. Read relevant files BEFORE answering questions. Never make claims about code before investigating.
-- **Parallel tool calls** - If calling multiple tools with no dependencies between them, make all independent calls in parallel. Never use placeholders or guess missing parameters.
+- Eagerness - Do not jump into implementation or change files unless clearly instructed. When intent is ambiguous, default to research and recommendations rather than action. Only proceed with edits when the user explicitly requests them.
+- No speculation - Never speculate about code you have not opened. Read relevant files BEFORE answering questions. Never make claims about code before investigating.
+- Parallel tool calls - If calling multiple tools with no dependencies between them, make all independent calls in parallel. Never use placeholders or guess missing parameters.
 
 ## Commands
 
@@ -211,11 +211,11 @@ npm run typecheck        # TypeScript type checking without emit
 
 ## Key Standards (Quick Reference)
 
-- **TypeScript strict mode** - No implicit any, strict null checks
-- **Prettier** - Single quotes, 2-space indent, 100-char width, no trailing commas
-- **ESLint** - Prefer const, unused vars prefixed with `_`, no floating promises
-- **Commits** - Conventional format: `type(scope): description`
-- **Branches** - Format: `type/description` (e.g., `feature/user-auth`, `fix/login-bug`)
+- TypeScript strict mode - No implicit any, strict null checks
+- Prettier - Single quotes, 2-space indent, 100-char width, no trailing commas
+- ESLint - Prefer const, unused vars prefixed with `_`, no floating promises
+- Commits - Conventional format: `type(scope): description`
+- Branches - Format: `type/description` (e.g., `feature/user-auth`, `fix/login-bug`)
 
 ## Session Workflow
 
@@ -239,4 +239,4 @@ Add any additional notes, context, or information that agents should know here. 
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for branching strategy, commit guidelines, pull request process, and testing requirements.
 
-**Important:** Keep this file synchronized and updated. This is the bridge between different experts working on the same project.
+Important: Keep this file synchronized and updated. This is the bridge between different experts working on the same project.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,22 +26,22 @@ docs/                # Developer documentation
 
 ## Directory Conventions
 
-- **controllers/** - Handle incoming requests and orchestrate responses
-- **services/** - Contain business logic, database operations, external API calls
-- **models/** - Data structures, interfaces, type definitions
-- **middleware/** - Authentication, logging, error handling, validation
-- **utils/** - Pure functions, helpers, shared utilities
-- **types/** - TypeScript interfaces and types (can also inline in files if small)
+- controllers/ - Handle incoming requests and orchestrate responses
+- services/ - Contain business logic, database operations, external API calls
+- models/ - Data structures, interfaces, type definitions
+- middleware/ - Authentication, logging, error handling, validation
+- utils/ - Pure functions, helpers, shared utilities
+- types/ - TypeScript interfaces and types (can also inline in files if small)
 
 ## Technology Stack
 
-- **Runtime:** Node.js (v18+)
-- **Language:** TypeScript (strict mode, ESM)
-- **Package Manager:** npm
-- **Testing:** Vitest
-- **Linting:** ESLint 9 (flat config) + Prettier + Markdownlint
-- **Dev runner:** tsx (ESM-native TypeScript execution)
-- **Hooks:** Husky + lint-staged
+- Runtime: Node.js (v18+)
+- Language: TypeScript (strict mode, ESM)
+- Package Manager: npm
+- Testing: Vitest
+- Linting: ESLint 9 (flat config) + Prettier + Markdownlint
+- Dev runner: tsx (ESM-native TypeScript execution)
+- Hooks: Husky + lint-staged
 
 ## Configuration Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,4 +3,4 @@
 All project context, standards, commands, and agent behavior rules live in
 [AGENTS.md](./AGENTS.md) — the single source of truth for all AI agents.
 
-**Read `AGENTS.md` and `docs/project_log.md` before starting any work.**
+Read `AGENTS.md` and `docs/project_log.md` before starting any work.

--- a/CODE_STANDARDS.md
+++ b/CODE_STANDARDS.md
@@ -10,18 +10,18 @@ Related documents:
 
 ## Guiding Principles
 
-- **DRY** (Don't Repeat Yourself) - Every piece of knowledge should have a single, unambiguous, authoritative representation. Refactor repeated logic into reusable components.
-- **Iterate progressively** - Start with core features only. Gather feedback.
-- **No secrets in Git** - NEVER put unencrypted secrets in Git or other CMS systems.
-- **GitHub CLI** - Primary method for interacting with GitHub.
-- **Think first** - Present options before implementing. On larger objectives, present a phased plan.
-- **Markdown style** - Use bullet points, not numbered lists for content (section headers like `## Step 1` are fine). No bold text as a heading or pseudo-heading — see Markdownlint MD036 below.
+- DRY (Don't Repeat Yourself) - Every piece of knowledge should have a single, unambiguous, authoritative representation. Refactor repeated logic into reusable components.
+- Iterate progressively - Start with core features only. Gather feedback.
+- No secrets in Git - NEVER put unencrypted secrets in Git or other CMS systems.
+- GitHub CLI - Primary method for interacting with GitHub.
+- Think first - Present options before implementing. On larger objectives, present a phased plan.
+- Markdown style - Use bullet points, not numbered lists for content (section headers like `## Step 1` are fine). No bold text as a heading or pseudo-heading — see Markdownlint MD036 below.
 
 ## Language & Environment
 
-- **Language:** English (US) for all code and documentation
-- **Runtime:** Node.js with TypeScript
-- **Target:** ES2020
+- Language: English (US) for all code and documentation
+- Runtime: Node.js with TypeScript
+- Target: ES2020
 
 ## TypeScript Configuration
 
@@ -105,7 +105,7 @@ Key rules:
 - Line length limits (300 chars general, 80 for headings)
 - Blank lines around lists and code blocks
 - Consistent list marker style
-- **No bold text as headings (MD036)** - Use proper heading syntax (`##`, `###`, etc.) instead of `**Bold:**`
+- No bold text as headings (MD036) - Use proper heading syntax (`##`, `###`, etc.) instead of `**Bold:**`
 
 Run markdown linting:
 
@@ -131,11 +131,11 @@ npm run lint:md:fix   # Auto-fix markdown issues (note: MD036 requires manual fi
 
 ## Naming Conventions
 
-- **Files:** Use kebab-case for file names (e.g., `user-service.ts`, `auth-controller.ts`)
-- **Classes:** Use PascalCase (e.g., `UserService`, `AuthController`)
-- **Functions/Variables:** Use camelCase (e.g., `getUserById`, `isActive`)
-- **Constants:** Use UPPER_SNAKE_CASE (e.g., `MAX_RETRIES`, `DEFAULT_TIMEOUT`)
-- **Private members:** Prefix with underscore (e.g., `_internalState`, `_validateInput()`)
+- Files: Use kebab-case for file names (e.g., `user-service.ts`, `auth-controller.ts`)
+- Classes: Use PascalCase (e.g., `UserService`, `AuthController`)
+- Functions/Variables: Use camelCase (e.g., `getUserById`, `isActive`)
+- Constants: Use UPPER_SNAKE_CASE (e.g., `MAX_RETRIES`, `DEFAULT_TIMEOUT`)
+- Private members: Prefix with underscore (e.g., `_internalState`, `_validateInput()`)
 
 ## Code Organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ npm run test:coverage     # Check coverage
 
 ## Commit Guidelines
 
-**All commit messages must follow the format specified in [CODE_STANDARDS.md - Git Commit Messages](./CODE_STANDARDS.md#git-commit-messages).**
+All commit messages must follow the format specified in [CODE_STANDARDS.md - Git Commit Messages](./CODE_STANDARDS.md#git-commit-messages).
 
 This includes:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A Node.js/TypeScript project template with production-ready tooling, code standa
 
 ### Prerequisites
 
-- **Node.js** v18+ (`node --version`) — [download](https://nodejs.org/)
-- **npm** v9+ (`npm --version`)
-- **Git** (`git --version`)
+- Node.js v18+ (`node --version`) — [download](https://nodejs.org/)
+- npm v9+ (`npm --version`)
+- Git (`git --version`)
 
 ### Setup
 
@@ -48,24 +48,24 @@ npm run typecheck        # TypeScript type checking without emit
 
 ## Documentation
 
-- **[AGENTS.md](AGENTS.md)** - Project context, status, and AI agent collaboration
-- **[CODE_STANDARDS.md](CODE_STANDARDS.md)** - Code quality, style, and guiding principles
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Project structure and patterns
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Development workflow and PRs
-- **[SECURITY.md](SECURITY.md)** - Security guidelines and best practices
-- **[.github/workflows/README.md](.github/workflows/README.md)** - CI/CD pipelines
+- [AGENTS.md](AGENTS.md) - Project context, status, and AI agent collaboration
+- [CODE_STANDARDS.md](CODE_STANDARDS.md) - Code quality, style, and guiding principles
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Project structure and patterns
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Development workflow and PRs
+- [SECURITY.md](SECURITY.md) - Security guidelines and best practices
+- [.github/workflows/README.md](.github/workflows/README.md) - CI/CD pipelines
 
 ## What's Included
 
 ### Code Quality Tools
 
-- **TypeScript** - Strict type checking
-- **ESLint 9** - Code quality with flat config (`eslint.config.mjs`)
-- **Vitest** - Fast test runner
-- **Prettier** - Automatic code formatting
-- **Markdownlint** - Documentation consistency
-- **EditorConfig** - Cross-editor consistency
-- **Husky + lint-staged** - Pre-commit hooks on changed files only
+- TypeScript - Strict type checking
+- ESLint 9 - Code quality with flat config (`eslint.config.mjs`)
+- Vitest - Fast test runner
+- Prettier - Automatic code formatting
+- Markdownlint - Documentation consistency
+- EditorConfig - Cross-editor consistency
+- Husky + lint-staged - Pre-commit hooks on changed files only
 
 ### Configuration Files
 
@@ -82,20 +82,20 @@ npm run typecheck        # TypeScript type checking without emit
 
 ### GitHub Integration
 
-- **CI workflow** - Lint, typecheck, test, build, security audit
-- **Deploy workflow** - Production deployment template
-- **PR template** - Standardized pull request format
-- **Issue templates** - Bug reports and feature requests
+- CI workflow - Lint, typecheck, test, build, security audit
+- Deploy workflow - Production deployment template
+- PR template - Standardized pull request format
+- Issue templates - Bug reports and feature requests
 
 ## Using This Template
 
 ### For New Projects
 
-- **Clone** this template
-- **Run** `npm install`
-- **Update** AGENTS.md with your project context
-- **Update** README.md with your project details
-- **Start developing** following CODE_STANDARDS.md
+- Clone this template
+- Run `npm install`
+- Update AGENTS.md with your project context
+- Update README.md with your project details
+- Start developing following CODE_STANDARDS.md
 
 ### For Existing Projects
 
@@ -105,10 +105,10 @@ See [TEMPLATE_INTEGRATION.md](TEMPLATE_INTEGRATION.md) for the smart merge utili
 
 This template supports teams and AI agents collaborating:
 
-- **AGENTS.md** - Single source of truth for project state (works with any AI agent)
-- **CLAUDE.md** - Thin pointer to AGENTS.md (auto-loaded by Claude Code)
-- **CODE_STANDARDS.md** - Coding rules and guiding principles
-- **CONTRIBUTING.md** - Development workflow
+- AGENTS.md - Single source of truth for project state (works with any AI agent)
+- CLAUDE.md - Thin pointer to AGENTS.md (auto-loaded by Claude Code)
+- CODE_STANDARDS.md - Coding rules and guiding principles
+- CONTRIBUTING.md - Development workflow
 
 ## Troubleshooting
 
@@ -135,10 +135,10 @@ PORT=3001 npm run dev
 
 ## Customization
 
-- **README.md** - Add project-specific information
-- **CODE_STANDARDS.md** - Adjust rules for your team
-- **package.json** - Update project name and dependencies
-- **.env.example** - Add your required environment variables
-- **ARCHITECTURE.md** - Document your specific architecture
-- **SECURITY.md** - Review and customize security policies
-- **.github/workflows/** - Configure CI/CD for your deployment target
+- README.md - Add project-specific information
+- CODE_STANDARDS.md - Adjust rules for your team
+- package.json - Update project name and dependencies
+- .env.example - Add your required environment variables
+- ARCHITECTURE.md - Document your specific architecture
+- SECURITY.md - Review and customize security policies
+- .github/workflows/ - Configure CI/CD for your deployment target

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ This document outlines security best practices and policies for this project. Al
 
 ### Never Commit Secrets
 
-**Critical Rule:** Never commit passwords, API keys, tokens, or other secrets to version control.
+Critical Rule: Never commit passwords, API keys, tokens, or other secrets to version control.
 
 ### What Counts as a Secret
 
@@ -77,7 +77,7 @@ This document outlines security best practices and policies for this project. Al
 
 If you accidentally commit a secret:
 
-1. **Immediately rotate the secret** (change the password/key)
+1. Immediately rotate the secret (change the password/key)
 2. Remove from git history:
 
    ```bash
@@ -115,25 +115,25 @@ This project includes GitHub Actions workflows that automatically audit dependen
 
 ### Updating Dependencies
 
-1. **Regular updates:**
+1. Regular updates:
 
    ```bash
    npm update
    npm outdated  # See what can be updated
    ```
 
-2. **Patch security issues immediately:**
+2. Patch security issues immediately:
 
    ```bash
    npm audit fix
    ```
 
-3. **Major version updates:**
+3. Major version updates:
    - Test thoroughly before merging
    - Check changelog for breaking changes
    - Update code if necessary
 
-4. **Audit before commit:**
+4. Audit before commit:
 
    ```bash
    npm audit
@@ -320,18 +320,18 @@ const isValid = await bcrypt.compare(inputPassword, storedHash);
 
 Maintain separate environments:
 
-- **Development**: Local, lenient security
-- **Staging**: Production-like, test environment
-- **Production**: Maximum security, restricted access
+- Development: Local, lenient security
+- Staging: Production-like, test environment
+- Production: Maximum security, restricted access
 
 ### Secure Deployment
 
-1. **Code review required** before production deployment
-2. **Automated tests must pass** (CI/CD pipeline)
-3. **Security scans must pass** (no high/critical vulnerabilities)
-4. **Secrets injected at runtime** (never in code)
-5. **Immutable deployments** (rollback capability)
-6. **Monitoring and alerting enabled**
+1. Code review required before production deployment
+2. Automated tests must pass (CI/CD pipeline)
+3. Security scans must pass (no high/critical vulnerabilities)
+4. Secrets injected at runtime (never in code)
+5. Immutable deployments (rollback capability)
+6. Monitoring and alerting enabled
 
 ### Access Control
 
@@ -356,10 +356,10 @@ Maintain separate environments:
 
 If you discover a vulnerability:
 
-1. **Do not** create a public GitHub issue
-2. **Do not** commit details in code comments
-3. **Do** email security contact privately
-4. **Do** provide:
+1. Do not create a public GitHub issue
+2. Do not commit details in code comments
+3. Do email security contact privately
+4. Do provide:
    - Detailed description
    - Steps to reproduce
    - Severity assessment
@@ -367,10 +367,10 @@ If you discover a vulnerability:
 
 ### Vulnerability Response Timeline
 
-- **Critical (CVSS 9.0-10)**: Fix within 24 hours
-- **High (CVSS 7.0-8.9)**: Fix within 1 week
-- **Medium (CVSS 4.0-6.9)**: Fix within 2 weeks
-- **Low (CVSS 0.1-3.9)**: Fix within 30 days
+- Critical (CVSS 9.0-10): Fix within 24 hours
+- High (CVSS 7.0-8.9): Fix within 1 week
+- Medium (CVSS 4.0-6.9): Fix within 2 weeks
+- Low (CVSS 0.1-3.9): Fix within 30 days
 
 ### Public Disclosure
 
@@ -407,11 +407,11 @@ Before deploying to production:
 
 ### Security Tools
 
-- **npm audit** - Check for known vulnerabilities
-- **OWASP ZAP** - Automated security scanning
-- **Snyk** - Continuous vulnerability scanning
-- **GitHub Advanced Security** - Code scanning and secret scanning
-- **Dependabot** - Automated dependency updates
+- npm audit - Check for known vulnerabilities
+- OWASP ZAP - Automated security scanning
+- Snyk - Continuous vulnerability scanning
+- GitHub Advanced Security - Code scanning and secret scanning
+- Dependabot - Automated dependency updates
 
 ### Learning Resources
 

--- a/TEMPLATE_INTEGRATION.md
+++ b/TEMPLATE_INTEGRATION.md
@@ -6,13 +6,13 @@ This guide explains how to apply this project template to your existing or new p
 
 The integration script applies all improvements from this template:
 
-- **Documentation standards** (DRY principle, Single Source of Truth)
-- **Agent Context Protocol** (YAML frontmatter, priority matrix)
-- **Markdownlint enforcement** (MD036 rule, consistent formatting)
-- **Complete package.json** with all quality tooling
-- **Config files** (eslint.config.mjs, .prettierrc.json, .markdownlint.json, tsconfig.json)
-- **Pre-commit hooks** (Husky with code + markdown linting)
-- **Documentation templates** (AGENTS.md, CODE_STANDARDS.md, etc.)
+- Documentation standards (DRY principle, Single Source of Truth)
+- Agent Context Protocol (YAML frontmatter, priority matrix)
+- Markdownlint enforcement (MD036 rule, consistent formatting)
+- Complete package.json with all quality tooling
+- Config files (eslint.config.mjs, .prettierrc.json, .markdownlint.json, tsconfig.json)
+- Pre-commit hooks (Husky with code + markdown linting)
+- Documentation templates (AGENTS.md, CODE_STANDARDS.md, etc.)
 
 ## Integration Methods
 
@@ -75,24 +75,24 @@ When running the script, you'll see three options:
 
 ### [N] Normal Copy (Safe for existing projects)
 
-- **Copies:** Only NEW files that don't exist in your project
-- **Skips:** All existing files (won't overwrite your code)
-- **Use when:** Adding template to existing project with custom code
-- **Safe:** Yes - won't touch your existing files
-- **⚠️ Limitation:** You'll miss new sections added to existing files (like AGENTS.md improvements)
+- Copies: Only NEW files that don't exist in your project
+- Skips: All existing files (won't overwrite your code)
+- Use when: Adding template to existing project with custom code
+- Safe: Yes - won't touch your existing files
+- ⚠️ Limitation: You'll miss new sections added to existing files (like AGENTS.md improvements)
 
 ### [O] Overwrite All (Destructive!)
 
-- **Copies:** ALL template files
-- **Overwrites:** Any existing files with same names
-- **Use when:** You want to completely reset to template standards
-- **Safe:** No - destroys custom content!
-- **⚠️ Warning:** You'll lose project-specific content in AGENTS.md, package.json, etc.
+- Copies: ALL template files
+- Overwrites: Any existing files with same names
+- Use when: You want to completely reset to template standards
+- Safe: No - destroys custom content!
+- ⚠️ Warning: You'll lose project-specific content in AGENTS.md, package.json, etc.
 
 ### [C] Cancel
 
-- **Does:** Nothing
-- **Use when:** You want to review what would change first
+- Does: Nothing
+- Use when: You want to review what would change first
 
 ## BETTER OPTION: Smart Merge (Recommended for Existing Projects)
 
@@ -123,21 +123,21 @@ npx ts-node merge-template.ts \
 
 ### What Smart Merge Does
 
-**For AGENTS.md:**
+#### For AGENTS.md
 
 - ✅ Adds NEW sections: Agent Context Protocol, Priority Matrix, Known Limitations
 - ✅ Keeps EXISTING content: Your project name, description, custom sections
 - ✅ Updates YAML frontmatter: Merges intelligently
 - ✅ Preserves custom sections: Any sections you added
 
-**For package.json:**
+#### For package.json
 
 - ✅ Adds NEW scripts: lint:md, lint:md:fix, typecheck
 - ✅ Adds NEW dependencies: markdownlint-cli, husky
 - ✅ Keeps YOUR metadata: name, version, description, author
 - ✅ Merges dependencies: Combines template + your existing deps
 
-**Example:**
+#### Example
 
 ```markdown
 <!-- Your existing AGENTS.md -->
@@ -271,10 +271,10 @@ npm run prepare
 
 Update these files for your project:
 
-- **ARCHITECTURE.md** - Document your actual architecture
-- **SECURITY.md** - Review and customize security policies
-- **README.md** - Add project-specific information
-- **CONTRIBUTING.md** - Adjust workflow if needed
+- ARCHITECTURE.md - Document your actual architecture
+- SECURITY.md - Review and customize security policies
+- README.md - Add project-specific information
+- CONTRIBUTING.md - Adjust workflow if needed
 
 ## Troubleshooting
 
@@ -312,31 +312,31 @@ git status                # See all changes
 
 ### For Existing Projects with Custom Content
 
-1. **Use Smart Merge** - Intelligently combines template + your content
-2. **Run with --dry-run first** - Preview changes before applying
-3. **Review backups** - Smart merge creates .backup files
-4. **Test thoroughly** - Run `npm run lint` after merge
+1. Use Smart Merge - Intelligently combines template + your content
+2. Run with --dry-run first - Preview changes before applying
+3. Review backups - Smart merge creates .backup files
+4. Test thoroughly - Run `npm run lint` after merge
 
 ### For Existing Projects (Simple/New)
 
-1. **Use Normal Copy [N]** - If you have minimal custom content
-2. **Review new files** before committing
-3. **Manually update** key files like AGENTS.md if needed
-4. **Test thoroughly** after integration
+1. Use Normal Copy [N] - If you have minimal custom content
+2. Review new files before committing
+3. Manually update key files like AGENTS.md if needed
+4. Test thoroughly after integration
 
 ### For New Projects
 
-1. **Clone template directly** (Method 3)
-2. **Update all project-specific values**
-3. **Delete unused files** (if any)
-4. **Start coding** with best practices built-in
+1. Clone template directly (Method 3)
+2. Update all project-specific values
+3. Delete unused files (if any)
+4. Start coding with best practices built-in
 
 ### For Team Projects
 
-1. **Create feature branch** for integration
-2. **Review changes** with team
-3. **Update docs together** to match your workflow
-4. **Merge after approval**
+1. Create feature branch for integration
+2. Review changes with team
+3. Update docs together to match your workflow
+4. Merge after approval
 
 ## What You Get
 


### PR DESCRIPTION
## Summary

- Strips all decorative bold-prefix labels from list items across the template's documentation. ~115 list-item changes plus ~30 standalone pseudo-heading conversions.
- Net: every doc file now reads consistently with the Markdownlint MD036 rule the template itself defines.
- `npm run lint:md` passes clean locally.

## Patterns handled

```
- **Foo:** content          → - Foo: content
1. **Foo** - content        → 1. Foo - content
- [link](url) - **Foo:** x  → - [link](url) - Foo: x
**Foo:** content (standalone) → Foo: content
**Foo:** (sub-section header) → #### Foo
```

## What's preserved

- Mid-line emphasis (`Husky + lint-staged runs linting on **changed files only**`) — intact, this is real emphasis not pseudo-heading.
- The single `**Update Requirements:**` line at `CODE_STANDARDS.md:121` — left as-is because it sits inside a fenced code block illustrating the MD036 bad pattern. Stripping it would erase the rule's own example.

## Files

| File | List-item changes |
|---|---|
| AGENTS.md | 15 |
| ARCHITECTURE.md | 13 |
| CODE_STANDARDS.md | 15 |
| CONTRIBUTING.md | 1 (over-promoted heading demoted to text) |
| README.md | 36 |
| SECURITY.md | 28 |
| TEMPLATE_INTEGRATION.md | 42 |
| CLAUDE.md | 1 |
| .claude/README.md | 18 |
| .claude/commands/sync-template.md | 7 |
| .github/workflows/README.md | 13 |
| .github/ISSUE_TEMPLATE/bug_report.md | 2 |

Net: 12 files, 191 insertions, 191 deletions (symmetric — every change is `**Foo**` → `Foo` shape).

## Test Plan

- [x] `npm run lint:md` passes clean locally
- [x] No `.ts` files touched; typecheck/test/build unaffected
- [ ] CI confirms (this PR's verification)

## Checklist

- [x] Code follows [CODE_STANDARDS.md](../CODE_STANDARDS.md)
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow conventional format
- [x] AGENTS.md updated — yes, included in the sweep