### PR TITLE
feat(pstatus): link open PRs to their related issues

### DIFF
--- a/.claude/commands/pstatus.md
+++ b/.claude/commands/pstatus.md
@@ -18,10 +18,10 @@ recommends what to do next. It does not start work.
   - `gh api "/repos/{owner}/{repo}/code-scanning/alerts?state=open"` (ignore a 404 — feature off)
   - any other scanner signal available (e.g. GitGuardian)
 - `gh issue list --state open --limit 100 --json number,title,labels`
-- `gh pr list --state open --limit 50 --json number,title,isDraft,mergeStateStatus,createdAt,labels`
+- `gh pr list --state open --limit 50 --json number,title,isDraft,mergeStateStatus,createdAt,labels,body,closingIssuesReferences`
   — `gh issue list` does **not** return PRs, so without this they are invisible to every band
   below. A merge-ready security PR can sit open across repeated `/pstatus` runs and never be
-  mentioned once.
+  mentioned once. `closingIssuesReferences` and `body` feed the PR ↔ issue linkage in Step 4.
 - `git log --oneline -5`
 - Read the last entries of `private/project_log.md` for session continuity.
 
@@ -68,9 +68,33 @@ issues, no bare `#<num>`. Each line:
 
 `- [#<num>](https://github.com/{owner}/{repo}/issues/<num>) — <title>`
 
-PRs use the same one-per-line rule with the `/pull/` path:
+PRs use the same one-per-line rule with the `/pull/` path, and **must name their related issues**:
 
-`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> *(ready | draft | conflicted)*`
+`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> *(ready | draft | conflicted)* — closes [#<n>](…/issues/<n>)`
+
+#### Resolving a PR's related issues
+
+A PR shown without its issue context reads as unrelated housekeeping, so resolve the link for every
+PR in the band. In order:
+
+1. **Declared** — `closingIssuesReferences` from Step 1. These are the issues GitHub will
+   auto-close on merge; render them as `closes #<n>`.
+2. **Mentioned** — any `#<n>` in the PR body that is not a closing reference; render as `refs #<n>`.
+3. **Inferred** — for a dependency-bump PR with neither, match the package name against open
+   `security` issue titles and bodies (including the `scanner-alert:` markers from Step 2). A
+   Dependabot PR bumping package `X` and a tracking issue for an advisory in `X` are the same work
+   arriving from two directions. Render as `likely #<n>` — never as `closes`, since it is a guess.
+
+If none of the three resolve, write `no linked issue` explicitly rather than leaving the line bare.
+A silent absence is indistinguishable from "not checked".
+
+Cross-reference both ways: an issue whose fix is already sitting in an open PR is **not** actually
+open work. Annotate it in its own priority band as `— PR open: [#<pr>](…/pull/<pr>)` so the ranking
+does not recommend starting something that is already written.
+
+Where a PR turns out to be redundant — the change is already on the default branch, or a tracking
+issue was resolved another way — say so on the PR line as `*(redundant — already on <branch>)*`.
+Stale dependency PRs routinely outlive the fix that superseded them.
 
 ### Step 5: Brief the user
 
@@ -80,6 +104,9 @@ P0 (else the top P1, and so on) with one line of why. Stop. Do not begin the wor
 A **merge-ready PR outranks starting new work** when it carries a security fix or a dependency
 bump: it is finished work sitting one click from shipping, so leaving it open while beginning
 something else is strictly worse than merging it first.
+
+State the PR ↔ issue linkage in the recommendation itself. "Merge #24 — it closes P0 #25" is
+actionable; "merge #24" alone makes the operator go look up why it matters.
 
 ## `/pstatus --all` (portfolio sweep — read-only, no writes)
 


### PR DESCRIPTION
Follow-up to #21. Closes #28.

## Problem

#21 gave `/pstatus` an `🔀 Open PRs` band, but the band says nothing about *why* any given PR matters. A Dependabot bump rendered as bare housekeeping outranks nothing — even when it is the fix for a `P0` security issue.

That happened in this repo, in the session that prompted this change. `/pstatus` surfaced two `P0` security issues (#25, #26) and, separately, two open Dependabot PRs. Each PR was the fix for one of the issues. The briefing never connected them.

## Why declared links are not enough

Dependabot writes no `Closes #n`, so `closingIssuesReferences` is empty on exactly the PRs where the linkage carries the most weight:

```console
$ gh pr list --state open --json number,closingIssuesReferences
27 closes=[]   # brace-expansion 5.0.8 + eslint  -> fixes P0 #26
24 closes=[]   # js-yaml 4.3.0                   -> fixes P0 #25
```

The link has to be inferred from the package name against open `security` issues and their `scanner-alert:` markers.

## Changes

- **Step 1** also gathers `body` and `closingIssuesReferences`.
- **Step 4** resolves related issues in three tiers — declared (`closes`), mentioned (`refs`), inferred by package-name match (`likely`). An inferred match is never rendered as `closes`; it is a guess and is labelled as one.
- An unresolved PR must say `no linked issue` outright — a silent absence is indistinguishable from "not checked".
- Issues are annotated in reverse with `PR open: #<n>`, so the ranking stops recommending work that is already written.
- Redundant PRs whose change already landed on the default branch are marked as such.
- **Step 5** states the linkage in the recommendation itself: "merge #24 — it closes P0 #25".

## Verification

The `gh` field set was checked against this repo's live PRs (output above). `markdownlint` passes on the edited file.

Docs-only change to `.claude/commands/pstatus.md` — no source, no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)