### PR TITLE
feat(kit): add --pr mode to install-kit.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,28 @@ create-if-absent, manages the AGENTS.md block, and migrates `docs/project_log.md
 
 ```bash
 ./install-kit.sh --dry-run /path/to/repo   # preview every change
-./install-kit.sh /path/to/repo             # apply
+./install-kit.sh /path/to/repo             # apply in place, leaving changes uncommitted
 /path/to/repo/utility/sync-labels.sh owner/repo   # apply the standard GitHub labels
 ```
+
+#### Syncing via pull request
+
+`--pr` applies the kit on a `chore/kit-sync-<version>` branch, commits, pushes, and opens a PR
+instead of leaving changes in your working tree. This is the preferred way to sync a downstream
+repo: the `AGENTS.md` this script installs requires feature branches and PRs for the default
+branch, and downstream CI (`markdown-lint`) only runs on PRs — so a direct push skips both.
+
+```bash
+./install-kit.sh --pr /path/to/repo           # branch, commit, push, open PR
+./install-kit.sh --auto-merge /path/to/repo   # same, and land it when CI goes green
+./install-kit.sh --dry-run --pr /path/to/repo # preview, touching nothing
+```
+
+Requires an authenticated `gh`, an `origin` remote, and a clean working tree — the sync must be the
+only change in the PR. It detects `master` vs `main` rather than assuming, restores the branch you
+started on (including on failure), and reports "already at kit `<version>`" without opening an empty
+PR when there is nothing to apply. A repo synced over SSH without `gh` must be synced without
+`--pr`.
 
 ## For Teams
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ branch, and downstream CI (`markdown-lint`) only runs on PRs — so a direct pus
 
 ```bash
 ./install-kit.sh --pr /path/to/repo           # branch, commit, push, open PR
-./install-kit.sh --auto-merge /path/to/repo   # same, and land it when CI goes green
 ./install-kit.sh --dry-run --pr /path/to/repo # preview, touching nothing
 ```
+
+The PR is left open for a human to merge — the script never lands it.
 
 Requires an authenticated `gh`, an `origin` remote, and a clean working tree — the sync must be the
 only change in the PR. It detects `master` vs `main` rather than assuming, restores the branch you

--- a/docs/sync-log.md
+++ b/docs/sync-log.md
@@ -3,7 +3,7 @@
 Current sync state for each downstream repo. The `KIT:START` comment in each repo's `AGENTS.md`
 is the authoritative per-file version record; this table tracks the repo-level picture.
 
-**Method:** sync with `install-kit.sh --pr` (or `--auto-merge`), which opens a PR rather than
+**Method:** sync with `install-kit.sh --pr`, which opens a PR rather than
 pushing to the default branch. Direct pushes bypass the downstream `markdown-lint` CI and violate
 the feature-branch rule the kit itself installs. Record the method actually used per repo below —
 a repo without `gh` available cannot use `--pr`.

--- a/docs/sync-log.md
+++ b/docs/sync-log.md
@@ -3,6 +3,18 @@
 Current sync state for each downstream repo. The `KIT:START` comment in each repo's `AGENTS.md`
 is the authoritative per-file version record; this table tracks the repo-level picture.
 
+**Method:** sync with `install-kit.sh --pr` (or `--auto-merge`), which opens a PR rather than
+pushing to the default branch. Direct pushes bypass the downstream `markdown-lint` CI and violate
+the feature-branch rule the kit itself installs. Record the method actually used per repo below —
+a repo without `gh` available cannot use `--pr`.
+
+**This table drifts.** It is written by hand, so treat the `KIT:START` marker in each downstream
+`AGENTS.md` as the truth and this table as a hint. Verify before relying on a row:
+
+```bash
+grep -o "KIT:START [^ ]*" /path/to/repo/AGENTS.md
+```
+
 **Excluded repos (permanent):**
 
 - `theak/jackery-homeassistant` — upstream fork, no push access; never sync.

--- a/install-kit.sh
+++ b/install-kit.sh
@@ -6,7 +6,7 @@
 #   Re-run   : safe anytime to pick up a newer kit version.
 #
 # Usage:
-#   install-kit.sh [--dry-run] [--pr] [--auto-merge] [target-dir]
+#   install-kit.sh [--dry-run] [--pr] [target-dir]
 #                                                # target-dir defaults to the current directory
 #
 # Sync modes:
@@ -15,8 +15,7 @@
 #                Requires an authenticated `gh`, an `origin` remote, and a clean working tree.
 #                Downstream AGENTS.md mandates feature branches + PRs for the default branch,
 #                and downstream CI (markdown-lint) only runs on PRs — a direct push skips both.
-#   --auto-merge implies --pr; also sets `gh pr merge --auto --squash` so a green sync lands
-#                unattended and only a failing one needs attention.
+#                The PR is left for a human to merge.
 #
 # Behavior per file:
 #   overwrite        canonical tool files (.claude/commands, sync-labels.sh, .markdownlint.jsonc)
@@ -36,13 +35,11 @@ set -euo pipefail
 
 DRY=0
 PR=0
-AUTO_MERGE=0
 TARGET=""
 for a in "$@"; do
   case "$a" in
-    --dry-run)    DRY=1 ;;
-    --pr)         PR=1 ;;
-    --auto-merge) PR=1; AUTO_MERGE=1 ;;
+    --dry-run) DRY=1 ;;
+    --pr)      PR=1 ;;
     -*) echo "unknown flag: $a" >&2; exit 2 ;;
     *) TARGET="$a" ;;
   esac
@@ -194,14 +191,6 @@ template rather than in this repo — the next sync would overwrite a local fix.
     echo "  PR: $url"
   else
     echo "  warning: branch pushed but no PR URL resolved — open one manually" >&2
-  fi
-
-  if [ "$AUTO_MERGE" -eq 1 ] && [ -n "$url" ]; then
-    if (cd "$TARGET" && gh pr merge --auto --squash "$url" >/dev/null 2>&1); then
-      echo "  auto-merge set — lands when CI passes"
-    else
-      echo "  warning: auto-merge not enabled (is it allowed on this repo?)" >&2
-    fi
   fi
 
   git -C "$TARGET" checkout --quiet "$PR_ORIG_BRANCH"

--- a/install-kit.sh
+++ b/install-kit.sh
@@ -6,7 +6,17 @@
 #   Re-run   : safe anytime to pick up a newer kit version.
 #
 # Usage:
-#   install-kit.sh [--dry-run] [target-dir]      # target-dir defaults to the current directory
+#   install-kit.sh [--dry-run] [--pr] [--auto-merge] [target-dir]
+#                                                # target-dir defaults to the current directory
+#
+# Sync modes:
+#   (default)    apply the kit in place, leaving the changes uncommitted for you to review
+#   --pr         apply on a `chore/kit-sync-<version>` branch, then commit, push, and open a PR.
+#                Requires an authenticated `gh`, an `origin` remote, and a clean working tree.
+#                Downstream AGENTS.md mandates feature branches + PRs for the default branch,
+#                and downstream CI (markdown-lint) only runs on PRs — a direct push skips both.
+#   --auto-merge implies --pr; also sets `gh pr merge --auto --squash` so a green sync lands
+#                unattended and only a failing one needs attention.
 #
 # Behavior per file:
 #   overwrite        canonical tool files (.claude/commands, sync-labels.sh, .markdownlint.jsonc)
@@ -18,14 +28,21 @@
 #   supersede        remove .markdownlint.json in favor of .markdownlint.jsonc
 #
 # Requires: bash, git, awk. (Run utility/sync-labels.sh separately for GitHub labels.)
+#           --pr additionally requires the `gh` CLI, authenticated.
+#
+# Note: macOS ships bash 3.2 — keep this script free of arrays, `mapfile`, and `${var,,}`.
 
 set -euo pipefail
 
 DRY=0
+PR=0
+AUTO_MERGE=0
 TARGET=""
 for a in "$@"; do
   case "$a" in
-    --dry-run) DRY=1 ;;
+    --dry-run)    DRY=1 ;;
+    --pr)         PR=1 ;;
+    --auto-merge) PR=1; AUTO_MERGE=1 ;;
     -*) echo "unknown flag: $a" >&2; exit 2 ;;
     *) TARGET="$a" ;;
   esac
@@ -40,6 +57,156 @@ START_PREFIX='<!-- KIT:START'
 END='<!-- KIT:END -->'
 
 act() { if [ "$DRY" -eq 1 ]; then printf '  [dry-run] %s\n' "$*"; else printf '  %s\n'  "$*"; fi; }
+
+# --- PR mode ----------------------------------------------------------------
+
+PR_BASE=""
+PR_BRANCH=""
+PR_ORIG_BRANCH=""
+
+pr_preflight() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "--pr requires the gh CLI, which is not on PATH." >&2
+    echo "  (repos synced over SSH without gh must be synced without --pr)" >&2
+    exit 2
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "--pr requires gh to be authenticated — run: gh auth login" >&2
+    exit 2
+  fi
+  if ! git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "--pr requires the target to be a git repo: $TARGET" >&2
+    exit 2
+  fi
+  if ! git -C "$TARGET" remote get-url origin >/dev/null 2>&1; then
+    echo "--pr requires an 'origin' remote in: $TARGET" >&2
+    exit 2
+  fi
+  if [ "$SRC" = "$TARGET" ]; then
+    echo "--pr refuses to run against the kit source repo itself: $SRC" >&2
+    exit 2
+  fi
+  # A dirty tree would sweep unrelated work into the sync commit.
+  if [ -n "$(git -C "$TARGET" status --porcelain)" ]; then
+    echo "--pr requires a clean working tree in: $TARGET" >&2
+    echo "  commit or stash first — the kit sync must be the only change in the PR" >&2
+    exit 2
+  fi
+}
+
+detect_default_branch() {  # master vs main, without assuming either
+  local b=""
+  b="$(cd "$TARGET" && gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)"
+  if [ -z "$b" ]; then
+    b="$(git -C "$TARGET" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    b="${b#origin/}"
+  fi
+  [ -n "$b" ] || b="master"
+  printf '%s' "$b"
+}
+
+pr_restore() {             # always leave the target on the branch we found it on
+  if [ "$PR" -eq 0 ] || [ "$DRY" -eq 1 ] || [ -z "$PR_ORIG_BRANCH" ]; then return 0; fi
+  local cur=""
+  cur="$(git -C "$TARGET" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ "$cur" != "$PR_ORIG_BRANCH" ]; then
+    git -C "$TARGET" checkout --quiet "$PR_ORIG_BRANCH" 2>/dev/null || true
+  fi
+}
+
+pr_begin() {
+  PR_BASE="$(detect_default_branch)"
+  PR_BRANCH="chore/kit-sync-$KIT_VERSION"
+  echo "PR mode:"
+  echo "  base branch : $PR_BASE"
+  echo "  sync branch : $PR_BRANCH"
+  if [ "$DRY" -eq 1 ]; then
+    echo "  [dry-run] would fetch origin, branch from origin/$PR_BASE, commit, push, and open a PR"
+    echo
+    return 0
+  fi
+  PR_ORIG_BRANCH="$(git -C "$TARGET" rev-parse --abbrev-ref HEAD)"
+  trap pr_restore EXIT
+  git -C "$TARGET" fetch --quiet origin "$PR_BASE"
+  if git -C "$TARGET" show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
+    git -C "$TARGET" checkout --quiet "$PR_BRANCH"
+    echo "  reusing existing sync branch"
+  else
+    git -C "$TARGET" checkout --quiet -b "$PR_BRANCH" "origin/$PR_BASE"
+  fi
+  echo
+}
+
+pr_finish() {
+  echo "PR mode — publishing:"
+  if [ "$DRY" -eq 1 ]; then
+    echo "  [dry-run] would commit the changes above, push $PR_BRANCH, and open a PR"
+    return 0
+  fi
+  if [ -z "$(git -C "$TARGET" status --porcelain)" ]; then
+    echo "  no changes — already at kit $KIT_VERSION"
+    git -C "$TARGET" checkout --quiet "$PR_ORIG_BRANCH"
+    git -C "$TARGET" branch -D "$PR_BRANCH" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  git -C "$TARGET" add -A
+  local files
+  files="$(git -C "$TARGET" diff --cached --name-status | sed 's/^/  /')"
+
+  git -C "$TARGET" commit --quiet -F - <<EOF
+chore(kit): sync to $KIT_VERSION
+
+Applied by install-kit.sh from mjs-project-template.
+
+Files changed:
+$files
+EOF
+
+  git -C "$TARGET" push --quiet -u origin "$PR_BRANCH"
+  echo "  pushed $PR_BRANCH"
+
+  local url=""
+  url="$(cd "$TARGET" && gh pr create \
+    --base "$PR_BASE" --head "$PR_BRANCH" \
+    --title "chore(kit): sync to $KIT_VERSION" \
+    --body "Automated kit sync from [mjs-project-template](https://github.com/jwilleke/mjs-project-template), applied by \`install-kit.sh\`.
+
+Kit version: \`$KIT_VERSION\`
+
+## Files changed
+
+\`\`\`text
+$files
+\`\`\`
+
+Canonical kit files are overwritten wholesale; your own content is untouched. \`AGENTS.md\` changes
+are confined to the managed block between the \`KIT:START\` / \`KIT:END\` markers.
+
+Merging when CI is green is the expected path. If a change here is wrong, fix it upstream in the
+template rather than in this repo — the next sync would overwrite a local fix." 2>/dev/null || true)"
+
+  if [ -z "$url" ]; then
+    # A PR for this branch may already be open from an earlier run.
+    url="$(cd "$TARGET" && gh pr view "$PR_BRANCH" --json url -q .url 2>/dev/null || true)"
+  fi
+  if [ -n "$url" ]; then
+    echo "  PR: $url"
+  else
+    echo "  warning: branch pushed but no PR URL resolved — open one manually" >&2
+  fi
+
+  if [ "$AUTO_MERGE" -eq 1 ] && [ -n "$url" ]; then
+    if (cd "$TARGET" && gh pr merge --auto --squash "$url" >/dev/null 2>&1); then
+      echo "  auto-merge set — lands when CI passes"
+    else
+      echo "  warning: auto-merge not enabled (is it allowed on this repo?)" >&2
+    fi
+  fi
+
+  git -C "$TARGET" checkout --quiet "$PR_ORIG_BRANCH"
+  echo "  restored branch: $PR_ORIG_BRANCH"
+}
 
 # --- behaviors --------------------------------------------------------------
 
@@ -217,6 +384,11 @@ echo "  into: $TARGET"
 [ "$DRY" -eq 1 ] && echo "  MODE: dry-run — no changes will be written"
 echo
 
+if [ "$PR" -eq 1 ]; then
+  pr_preflight
+  pr_begin
+fi
+
 echo "Canonical tool files (overwrite):"
 overwrite ".claude/commands/pstatus.md"
 overwrite ".claude/commands/session-commit.md"
@@ -259,9 +431,18 @@ seed ".github/ISSUE_TEMPLATE/config.yml"
 seed ".github/PULL_REQUEST_TEMPLATE.md"
 echo
 
+if [ "$PR" -eq 1 ]; then
+  pr_finish
+  echo
+fi
+
 echo "Done."
 echo "Next:"
 echo "  - utility/sync-labels.sh            # apply the standard GitHub labels to this repo"
 echo "  - /pstatus                          # rank work + regenerate TODO.md"
+if [ "$PR" -eq 0 ]; then
+  echo "  - review the changes above, then commit them on a feature branch"
+  echo "    (or re-run with --pr to branch, push, and open the PR for you)"
+fi
 if [ "$DRY" -eq 1 ]; then echo "  (re-run without --dry-run to apply the changes above)"; fi
 exit 0


### PR DESCRIPTION
Closes #30.

## Problem

Kit syncs land as direct pushes to each downstream repo's default branch.

**The kit contradicts itself.** The `AGENTS.md` this script installs into every downstream repo states:

```text
- All work must be done in feature branches
- Pull requests required for master branch
```

The installer was the one thing exempting itself from the rule it distributes.

**It skips the CI that would catch a bad sync.** Downstream repos run `markdown-lint.yml` (ngdpbase, yourphr, mj-infra-flux all have it), and the kit ships markdown. A direct push bypasses that check and lands in nine repos at once, unreviewed, with no signal on failure.

**It is invisible.** With the Open PRs band (#21) and PR ↔ issue linkage (#29), a pending sync now surfaces in the downstream repo's own `/pstatus`. A direct push leaves nothing to notice.

## Changes

`--pr` applies the kit on `chore/kit-sync-<version>`, commits, pushes, and opens a PR. `--auto-merge` implies `--pr` and additionally sets `gh pr merge --auto --squash`, so green syncs land unattended and only failures need attention. Without either flag, behavior is unchanged.

Guards:

- Refuses a dirty working tree, so unrelated work cannot ride along in the sync commit.
- Refuses to run against the kit source repo itself.
- Requires `gh` present, authenticated, with an `origin` remote — a repo synced over SSH without `gh` gets a clear error rather than a half-applied kit.
- Detects `master` vs `main` via `gh repo view` with a `git symbolic-ref` fallback rather than assuming.
- Restores the starting branch through an `EXIT` trap, including on failure.
- Reuses an existing sync branch; on a no-op run deletes it and reports `already at kit <version>` instead of opening an empty PR.

Kept free of arrays and `mapfile` for macOS bash 3.2 (see #17, #19).

## Verification

Exercised against a scratch repo with a local bare `origin`:

| path | result |
|---|---|
| self-target guard | refused |
| dirty working tree | refused, with the fix in the message |
| `--dry-run --pr` | full plan printed, nothing written |
| live run | branched, applied, committed, pushed, restored to `master` |
| idempotent re-run | `no changes — already at kit <version>`, branch deleted |
| `gh` unavailable for PR creation | branch still pushed, explicit warning |

**Not exercised:** `gh pr create` and `--auto-merge` against a real GitHub remote. The scratch origin is a local bare repo, so those paths fell through to the "no PR URL resolved" warning by design. First real use will be the pending 9-repo sync.

## Also in this PR

`docs/sync-log.md` gained a note that the table is hand-written and drifts — the `KIT:START` marker in each downstream `AGENTS.md` is the truth. This is not cosmetic: the table dates every row 2026-06-16 and claims `v1.0.0-13` for ngdpbase and `v1.0.0-12` for yourphr, while both actually read `v1.0.0-26-gc0e965b`. The other seven rows are accurate.

## Out of scope

The 9-repo sync run itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Corrections since this PR was opened

**`--auto-merge` was removed** (c12f769), per operator decision. CI green only proves markdown lints and tests pass — it does not prove the kit change was right *for that repo*, and nine repos self-merging on that signal is the unreviewed bulk change `--pr` exists to stop. `--pr` now opens the PR and stops; a human merges it. The flag is rejected as unknown if passed. Ignore the `--auto-merge` mentions in the Changes section above.

**`garage-car-positioning` is not a special case.** An earlier revision claimed it had no `KIT:START` marker and had never been properly kitted. That was read from a stale local clone (last commit `f14ab69`); the remote is kitted at `v1.0.0-12-g1fa177f`, same as five other repos. It is an ordinary sync target.

Verified state of all 9 downstream repos, read from each remote's `AGENTS.md` marker. Kit head is `v1.0.0-36-gc12f769`:

| repo | marker | has Open PRs band |
|---|---|---|
| garage-car-positioning | v1.0.0-12-g1fa177f | no |
| grow-nutrient-tank | v1.0.0-12-g1fa177f | no |
| grow-tent | v1.0.0-12-g1fa177f | no |
| jwilleke | v1.0.0-12-g1fa177f | no |
| mj-infra-flux | v1.0.0-12-g1fa177f | no |
| mjs-ha | v1.0.0-12-g1fa177f | no |
| ngdpbase | v1.0.0-26-gc0e965b | yes |
| yourphr | v1.0.0-26-gc0e965b | no |
| deby | v1.0.0-3-g02fd112 | no |

All nine are behind head. Eight lack the Open PRs band. The `deby` caveat is unchanged — it syncs over SSH and may have no `gh`, so `--pr` must fail cleanly there.
