### PR TITLE
docs: record the 2026-07-27 downstream sync, add downstream-repos.txt

### DIFF
--- a/docs/sync-log.md
+++ b/docs/sync-log.md
@@ -21,14 +21,45 @@ grep -o "KIT:START [^ ]*" /path/to/repo/AGENTS.md
 
 ## Current State
 
-| Repo | Last Synced | Kit Version | Method |
-| --- | --- | --- | --- |
-| [jwilleke/garage-car-positioning](https://github.com/jwilleke/garage-car-positioning) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/grow-nutrient-tank](https://github.com/jwilleke/grow-nutrient-tank) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/grow-tent](https://github.com/jwilleke/grow-tent) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/jwilleke](https://github.com/jwilleke/jwilleke) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/mj-infra-flux](https://github.com/jwilleke/mj-infra-flux) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/mjs-ha](https://github.com/jwilleke/mjs-ha) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/ngdpbase](https://github.com/jwilleke/ngdpbase) | 2026-06-16 | v1.0.0-13-g3083ea6 | install-kit.sh |
-| [jwilleke/yourphr](https://github.com/jwilleke/yourphr) | 2026-06-16 | v1.0.0-12-g1fa177f | install-kit.sh |
-| [jwilleke/deby](https://github.com/jwilleke/deby) | 2026-06-16 | v1.0.0-3-g02fd112 | install-kit.sh via SSH |
+`Kit Version` is the version **on the default branch**. A repo with an open sync PR is still at its
+old version until that PR merges.
+
+| Repo | Last Synced | Kit Version | Open sync PR | Method |
+| --- | --- | --- | --- | --- |
+| [jwilleke/garage-car-positioning](https://github.com/jwilleke/garage-car-positioning) | 2026-06-16 | v1.0.0-12-g1fa177f | [#17](https://github.com/jwilleke/garage-car-positioning/pull/17) | install-kit.sh --pr |
+| [jwilleke/grow-nutrient-tank](https://github.com/jwilleke/grow-nutrient-tank) | 2026-06-16 | v1.0.0-12-g1fa177f | [#18](https://github.com/jwilleke/grow-nutrient-tank/pull/18) | install-kit.sh --pr |
+| [jwilleke/grow-tent](https://github.com/jwilleke/grow-tent) | 2026-06-16 | v1.0.0-12-g1fa177f | [#6](https://github.com/jwilleke/grow-tent/pull/6) | install-kit.sh --pr |
+| [jwilleke/jwilleke](https://github.com/jwilleke/jwilleke) | 2026-06-16 | v1.0.0-12-g1fa177f | — | excluded from the 2026-07-27 sync by operator |
+| [jwilleke/mj-infra-flux](https://github.com/jwilleke/mj-infra-flux) | 2026-06-16 | v1.0.0-12-g1fa177f | — | skipped 2026-07-27 — untracked files in the working tree |
+| [jwilleke/mjs-ha](https://github.com/jwilleke/mjs-ha) | 2026-06-16 | v1.0.0-12-g1fa177f | [#27](https://github.com/jwilleke/mjs-ha/pull/27) | install-kit.sh --pr |
+| [jwilleke/ngdpbase](https://github.com/jwilleke/ngdpbase) | 2026-06-16 | v1.0.0-26-gc0e965b | [#994](https://github.com/jwilleke/ngdpbase/pull/994) | install-kit.sh --pr |
+| [jwilleke/yourphr](https://github.com/jwilleke/yourphr) | 2026-06-16 | v1.0.0-26-gc0e965b | [#398](https://github.com/jwilleke/yourphr/pull/398) | install-kit.sh --pr |
+| [jwilleke/deby](https://github.com/jwilleke/deby) | 2026-06-16 | v1.0.0-3-g02fd112 | [#30](https://github.com/jwilleke/deby/pull/30) | install-kit.sh --pr |
+
+## 2026-07-27 — first PR-based sync (v1.0.0-43-g7cf371c)
+
+Seven PRs opened with `install-kit.sh --pr`, the first use of PR mode against real remotes. All
+seven are `MERGEABLE`. `ngdpbase` ran first as a watched pilot before the rest followed.
+
+Two repos were not synced: `jwilleke` (excluded by the operator) and `mj-infra-flux`, whose working
+tree held two untracked files — `--pr` refuses a dirty tree, correctly, since it stages with
+`git add -A` and would otherwise sweep unrelated files into the sync commit. Commit or ignore those
+two files, then re-run.
+
+**`markdown-lint` fails on five of the seven PRs, and none of it is caused by the sync.** The
+failures are pre-existing violations in each repo's own documentation, in files no sync PR touches:
+
+| repo | total lint errors | errors in synced files |
+| --- | --- | --- |
+| grow-tent | 6 | 0 |
+| grow-nutrient-tank | 276 | 0 |
+| mjs-ha | 202 | 0 |
+| deby | 61 | 0 |
+| garage-car-positioning | 99 | 0 |
+
+`markdown-lint.yml` runs only on pull requests. These repos had not opened a PR since the workflow
+was seeded, so the violations were never surfaced. The sync PR is simply the first thing to run it.
+Expect this on any repo's first PR-based sync — triage it as that repo's own backlog, not as sync
+breakage. Errors reported under `.claude/commands/` in `deby` and `garage-car-positioning` are in
+repo-specific commands (`check-k8s.md`, `check-net.md`, `update-docs.md`) that the kit does not
+ship.

--- a/downstream-repos.txt
+++ b/downstream-repos.txt
@@ -24,8 +24,11 @@ jwilleke/mj-infra-flux
 jwilleke/mjs-ha
 jwilleke/ngdpbase
 jwilleke/yourphr
+jwilleke/fairways-gen2-website
 
 # Excluded — uncomment to bring back into the sync set.
 #
 # jwilleke/jwilleke              profile repo, not a project; excluded by operator 2026-07-27
+# jwilleke/js-rocket             3D-printing project, not a software project; no issues to rank,
+#                                never kitted; excluded by operator 2026-07-27
 # theak/jackery-homeassistant    upstream fork, no push access; permanent exclusion

--- a/downstream-repos.txt
+++ b/downstream-repos.txt
@@ -1,0 +1,31 @@
+# Downstream repos for the mjs agent kit.
+#
+# One owner/repo per line. Blank lines and lines starting with # are ignored.
+# Keep this machine-readable — it is consumed by tooling that fans out kit syncs.
+#
+# Read it with:
+#   grep -vE '^\s*(#|$)' downstream-repos.txt
+#
+# Example — open a kit-sync PR against every repo listed:
+#   grep -vE '^\s*(#|$)' downstream-repos.txt | while read -r repo; do
+#     ./install-kit.sh --pr "/Volumes/hd2A/workspaces/github/${repo#*/}"
+#   done
+#
+# Default branch varies (grow-tent and yourphr are `main`, the rest `master`).
+# Do not assume it — install-kit.sh --pr detects it per repo.
+#
+# Sync state and open sync PRs: docs/sync-log.md
+
+jwilleke/deby
+jwilleke/garage-car-positioning
+jwilleke/grow-nutrient-tank
+jwilleke/grow-tent
+jwilleke/mj-infra-flux
+jwilleke/mjs-ha
+jwilleke/ngdpbase
+jwilleke/yourphr
+
+# Excluded — uncomment to bring back into the sync set.
+#
+# jwilleke/jwilleke              profile repo, not a project; excluded by operator 2026-07-27
+# theak/jackery-homeassistant    upstream fork, no push access; permanent exclusion


### PR DESCRIPTION
Records the first real use of `install-kit.sh --pr` (#31) against downstream remotes.

## Result

Seven PRs opened at kit `v1.0.0-43-g7cf371c`, all `MERGEABLE`. `ngdpbase` ran first as a watched pilot before the rest followed.

| repo | sync PR | branch | changed files |
|---|---|---|---|
| ngdpbase | [#994](https://github.com/jwilleke/ngdpbase/pull/994) | master | 3 |
| yourphr | [#398](https://github.com/jwilleke/yourphr/pull/398) | **main** | 3 |
| grow-tent | [#6](https://github.com/jwilleke/grow-tent/pull/6) | **main** | 5 |
| grow-nutrient-tank | [#18](https://github.com/jwilleke/grow-nutrient-tank/pull/18) | master | 5 |
| mjs-ha | [#27](https://github.com/jwilleke/mjs-ha/pull/27) | master | 5 |
| deby | [#30](https://github.com/jwilleke/deby/pull/30) | master | 7 |
| garage-car-positioning | [#17](https://github.com/jwilleke/garage-car-positioning/pull/17) | master | 5 |

`--pr` behaved as designed: `master` vs `main` detected correctly on both `main` repos, `AGENTS.md` edits confined to the `KIT:START`/`KIT:END` managed block, and every local clone restored to its original branch, clean.

Two repos not synced:

- **jwilleke** — excluded by the operator.
- **mj-infra-flux** — two untracked files in the working tree. `--pr` refused it, correctly: `pr_finish` stages with `git add -A` and would otherwise have swept unrelated files into the sync commit. This is the dirty-tree guard doing its job on a real repo.

## markdown-lint fails on five PRs — not caused by the sync

| repo | total lint errors | errors in synced files |
|---|---|---|
| grow-tent | 6 | 0 |
| grow-nutrient-tank | 276 | 0 |
| mjs-ha | 202 | 0 |
| deby | 61 | 0 |
| garage-car-positioning | 99 | 0 |

Every failure is a pre-existing violation in that repo's own documentation, in files no sync PR touches. `markdown-lint.yml` runs only on pull requests, and these repos had not opened one since it was seeded — so hundreds of latent violations sat unsurfaced. The sync PR is simply the first thing to run it.

Worth knowing before merging those five: this is that repo's own documentation backlog, not sync breakage. Expect it on any repo's first PR-based sync.

Errors reported under `.claude/commands/` in `deby` and `garage-car-positioning` are in repo-specific commands (`check-k8s.md`, `check-net.md`, `update-docs.md`) that the kit does not ship.

## Table changes

- New **Open sync PR** column. `Kit Version` now explicitly means the version *on the default branch* — a repo with an open sync PR is still on its old version until that PR merges.
- Corrects two rows that were wrong: `ngdpbase` and `yourphr` were recorded as `v1.0.0-13` and `v1.0.0-12`; both actually read `v1.0.0-26-gc0e965b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also folded in: `downstream-repos.txt`

The repo set had to be reassembled from `docs/sync-log.md`, `gh repo list`, and local directory contents every time it was needed, so any script fanning out kit syncs carried its own hardcoded copy — which is how the set drifts.

`downstream-repos.txt` is a machine-readable list: one `owner/repo` per line, `#` comments and blanks ignored.

```console
$ grep -vE '^\s*(#|$)' downstream-repos.txt
jwilleke/deby
jwilleke/garage-car-positioning
jwilleke/grow-nutrient-tank
jwilleke/grow-tent
jwilleke/mj-infra-flux
jwilleke/mjs-ha
jwilleke/ngdpbase
jwilleke/yourphr
jwilleke/fairways-gen2-website
```

A sync loop becomes two lines:

```bash
grep -vE '^\s*(#|$)' downstream-repos.txt | while read -r repo; do
  ./install-kit.sh --pr "/Volumes/hd2A/workspaces/github/${repo#*/}"
done
```

### Exclusions stay in the file, commented, with reasons

Deleting them loses *why* they are absent and invites someone to add them back.

| repo | reason |
|---|---|
| `jwilleke/jwilleke` | Profile repo, not a project. Excluded by operator 2026-07-27. |
| `jwilleke/js-rocket` | 3D-printing project, not software. Private; contents are `rocket/`, `docs/`, `private/`, `README.md`. No `AGENTS.md`, no `.claude/commands`, no workflows — never kitted. Nothing for `/pstatus` to rank, and a first-time kitting would add a markdown-lint workflow that fails immediately on its existing docs. |
| `theak/jackery-homeassistant` | Upstream fork, no push access. Permanent. |

### Caution on `fairways-gen2-website`

It is in the active set but **not yet safe to sync**. Its local clone sits on an unpushed `chore/agent-kit-integration` branch, 4 commits ahead of `origin/master`, already integrating the kit at `3aa1bb4`:

```text
19d7f23 fix(lint): drop double blank line in PR template, lint dot-directories locally
9086c38 ci: remove deploy.yml and drop nonexistent scripts from the PR template
d689d30 docs: refresh TODO from issue labels
d49431a chore: integrate mjs-project-template agent kit (3aa1bb4)
```

That branch also carries hand work `install-kit.sh` does not reproduce — `TEMPLATE_INTEGRATION.md` trimmed by 415 lines, `package.json` edits, `deploy.yml` removed, `.markdownlint.json` migrated to `.jsonc`. Running `--pr` there branches from `origin/master` and would open a PR competing with it. **Push and PR that branch first.**

All nine entries verified resolvable via `gh repo view`. `grow-tent` and `yourphr` default to `main` rather than `master`.
