### PR TITLE
fix(sync-labels): survive an empty repo_args array on bash 3.2

### DIFF
--- a/utility/sync-labels.sh
+++ b/utility/sync-labels.sh
@@ -10,6 +10,10 @@
 #   utility/sync-labels.sh --all owner     # every active (non-archived, source) repo for owner
 #
 # Requires: gh (authenticated).
+#
+# Note: macOS ships bash 3.2, where `set -u` treats "${arr[@]}" on an EMPTY array as an
+# unbound variable (fixed in bash 4.4). Expand possibly-empty arrays as
+# ${arr[@]+"${arr[@]}"} — outer unquoted, inner quoted — or the no-arg path aborts.
 
 set -euo pipefail
 
@@ -35,7 +39,8 @@ apply_to() {
   local spec name color desc
   for spec in "${LABELS[@]}"; do
     IFS='|' read -r name color desc <<<"$spec"
-    gh label create "$name" --color "$color" --description "$desc" --force "${repo_args[@]}" >/dev/null
+    # ${repo_args[@]+...} — empty-safe on bash 3.2; a plain "${repo_args[@]}" aborts under set -u
+    gh label create "$name" --color "$color" --description "$desc" --force ${repo_args[@]+"${repo_args[@]}"} >/dev/null
     echo "   ✓ $name"
   done
 }


### PR DESCRIPTION
Closes #19. Closes #17 — same bug, filed twice.

## Problem

`utility/sync-labels.sh` with no argument — its documented *"current repo (gh infers from cwd)"* mode — aborted before creating a single label on stock macOS:

```console
$ utility/sync-labels.sh
→ labels: current repo
utility/sync-labels.sh: line 38: repo_args[@]: unbound variable
```

macOS ships bash 3.2, where `set -u` treats `"${arr[@]}"` on an **empty** array as an unbound variable. Bash 4.4 fixed this, so the script worked on Linux and failed on the machine it is mostly run from.

Passing an explicit `owner/repo` masked it — the array is then non-empty, which is why `--all` and the two-arg form were unaffected and the bug survived this long.

## Fix

```diff
-    gh label create "$name" ... --force "${repo_args[@]}" >/dev/null
+    gh label create "$name" ... --force ${repo_args[@]+"${repo_args[@]}"} >/dev/null
```

Outer unquoted so an empty array contributes no argument at all; inner quoted so a populated one is not word-split. Getting the quoting backwards would pass a single empty string as an argument.

## Verification

On `/bin/bash` 3.2.57 with a stubbed `gh`, so no labels were actually written:

| invocation | exit | label calls | calls carrying `-R` |
|---|---|---|---|
| `sync-labels.sh` | 0 | 9 | 0 |
| `sync-labels.sh jwilleke/ngdpbase` | 0 | 9 | 9 |

The pre-fix expansion still aborts on that same shell, so the change is what fixed it rather than an environment difference:

```console
$ /bin/bash -c 'set -euo pipefail; repo_args=(); f() { echo "$@"; }; f --force "${repo_args[@]}"'
/bin/bash: repo_args[@]: unbound variable
```

## Audit

Checked the rest of the kit for the same pattern:

```console
$ grep -rn '\${[a-zA-Z_][a-zA-Z0-9_]*\[@\]}' --include="*.sh" .
utility/sync-labels.sh:36:  for spec in "${LABELS[@]}"; do
utility/sync-labels.sh:38:    gh label create ... "${repo_args[@]}" ...
```

Only two. `LABELS[@]` is a hardcoded literal and can never be empty. `install-kit.sh` uses no arrays at all. Added a header note recording the bash 3.2 constraint so it is not reintroduced.

## Note on the duplicate

#17 and #19 describe the same defect — same file, same line, same cause, same proposed fix. Closing both. #19 records that this was already patched downstream in `jwilleke/geohazardwatch#128`; this brings the kit itself in line, so the next sync stops re-shipping the broken version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)