### PR TITLE
fix(pstatus): forbid duplicate entries, use underscore emphasis

### DIFF
--- a/.claude/commands/pstatus.md
+++ b/.claude/commands/pstatus.md
@@ -76,7 +76,28 @@ issues, no bare `#<num>`. Each line:
 
 PRs use the same one-per-line rule with the `/pull/` path, and **must name their related issues**:
 
-`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> *(ready | draft | conflicted)* — closes [#<n>](…/issues/<n>)`
+`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> _(ready | draft | conflicted)_ — closes [#<n>](…/issues/<n>)`
+
+Use **underscore** emphasis, not asterisks. The kit's own `.markdownlint.jsonc` sets MD049 to
+`underscore`, so an asterisk-wrapped state marker makes the generated `TODO.md` fail
+`npm run lint:md` in the very repo that produced it.
+
+**No entry may appear twice in `TODO.md`.** Every issue and every PR gets exactly one line in the
+whole file. When an issue's fix is already in an open PR, it belongs to the PR's line — as a
+`closes` / `refs` / `likely` link — and is **not** also listed in its priority band. Two lines for
+one piece of work inflates the apparent backlog and makes the file read as though the fix has not
+been written yet.
+
+State the absence rather than deleting it silently: a band whose only members moved to the PR
+section says so and names the count, e.g. `_None outstanding._ 2 untriaged issues exist (#17, #19)
+but both are awaiting merge — listed under 🔀 Open PRs`. An empty band and a band whose work is
+already done are different states, and the reader needs to tell them apart.
+
+Verify before finishing — every count must be 1:
+
+```bash
+grep -oE '/(issues|pull)/[0-9]+' TODO.md | sort | uniq -c | sort -rn
+```
 
 #### Resolving a PR's related issues
 
@@ -94,9 +115,10 @@ PR in the band. In order:
 If none of the three resolve, write `no linked issue` explicitly rather than leaving the line bare.
 A silent absence is indistinguishable from "not checked".
 
-Cross-reference both ways: an issue whose fix is already sitting in an open PR is **not** actually
-open work. Annotate it in its own priority band as `— PR open: [#<pr>](…/pull/<pr>)` so the ranking
-does not recommend starting something that is already written.
+An issue whose fix is already sitting in an open PR is **not** actually open work, and the ranking
+must not recommend starting something already written. Per the no-duplicate rule above, it is
+carried by the PR's line rather than annotated in its own band — one line, in the PR section, where
+the actionable verb is "merge" rather than "start".
 
 Where a PR turns out to be redundant — the change is already on the default branch, or a tracking
 issue was resolved another way — say so on the PR line as `*(redundant — already on <branch>)*`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,15 @@
 ---
 title: TODO
-description: Priority bands and resume pointer for mjs-project-template.
+description: Priority bands for mjs-project-template.
 last_updated: "2026-07-27"
-kit_version: "v1.0.0-28-g3aa1bb4"
+kit_version: "v1.0.0-44-g8042d50"
 ---
 
 # TODO
 
 ## 🔴 P0 — Security & Critical
 
-_None._
+_None._ No open Dependabot alerts; code scanning is not enabled on this repo.
 
 ## 🟠 P1
 
@@ -21,8 +21,7 @@ _None._
 
 ## 🔵 In review
 
-- [#22](https://github.com/jwilleke/mjs-project-template/issues/22) — [security] linkify-it — quadratic-complexity DoS via mailto: validator (high) — patched, awaiting close
-- [#23](https://github.com/jwilleke/mjs-project-template/issues/23) — [security] brace-expansion — exponential-time DoS via consecutive empty {} groups (high) — patched, awaiting close
+_None._
 
 ## ⏸ Deferred
 
@@ -30,8 +29,22 @@ _None._
 
 ## ❓ Needs triage
 
-3 open issues awaiting a priority decision:
+_None outstanding._ 2 untriaged issues exist (#17, #19) but both are already fixed and awaiting
+merge, so they are listed once under 🔀 Open PRs against the PR that closes them.
 
-- [#19](https://github.com/jwilleke/mjs-project-template/issues/19) — [BUG] sync-labels.sh crashes on no-arg run under bash 3.2 (set -u, empty array)
-- [#17](https://github.com/jwilleke/mjs-project-template/issues/17) — [BUG] sync-labels.sh fails on macOS bash 3.2: repo_args[@]: unbound variable
-- [#16](https://github.com/jwilleke/mjs-project-template/issues/16) — [BUG] AGENTS.md references .markdownlint.jsonc but the kit doesn't ship it
+## 🔀 Open PRs
+
+- [#35](https://github.com/jwilleke/mjs-project-template/pull/35) — fix(sync-labels): survive an empty repo_args array on bash 3.2 _(ready)_ — closes [#17](https://github.com/jwilleke/mjs-project-template/issues/17), closes [#19](https://github.com/jwilleke/mjs-project-template/issues/19)
+- [#34](https://github.com/jwilleke/mjs-project-template/pull/34) — docs: record the 2026-07-27 downstream sync, add downstream-repos.txt _(ready)_ — no linked issue
+
+## Downstream sync PRs (open, not tracked by the bands above)
+
+Opened by the 2026-07-27 kit sync. All `MERGEABLE`. See `docs/sync-log.md`.
+
+- [jwilleke/ngdpbase#994](https://github.com/jwilleke/ngdpbase/pull/994) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/yourphr#398](https://github.com/jwilleke/yourphr/pull/398) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/grow-tent#6](https://github.com/jwilleke/grow-tent/pull/6) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/grow-nutrient-tank#18](https://github.com/jwilleke/grow-nutrient-tank/pull/18) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/mjs-ha#27](https://github.com/jwilleke/mjs-ha/pull/27) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/deby#30](https://github.com/jwilleke/deby/pull/30) — chore(kit): sync to v1.0.0-43-g7cf371c
+- [jwilleke/garage-car-positioning#17](https://github.com/jwilleke/garage-car-positioning/pull/17) — chore(kit): sync to v1.0.0-43-g7cf371c


### PR DESCRIPTION
Two spec defects found by running `/pstatus` against this repo and **checking the output** rather than trusting it.

## 1. Every issue with an open fix appeared twice

The spec told `/pstatus` to cross-reference both ways — list an issue in its priority band annotated `PR open: #N`, *and* list the same issue on the PR's line as a `closes` link. So every issue whose fix was already written got two lines.

The generated `TODO.md` showed:

```markdown
## ❓ Needs triage
- [#19](…/issues/19) — sync-labels.sh crashes… — PR open: [#35](…/pull/35)
- [#17](…/issues/17) — sync-labels.sh fails… — PR open: [#35](…/pull/35)

## 🔀 Open PRs
- [#35](…/pull/35) — fix(sync-labels)… — closes [#17](…/issues/17), closes [#19](…/issues/19)
```

Four references to two issues. That inflates the apparent backlog and makes the file read as though the fix has not been written yet — the opposite of what the PR band was added for in #28/#29.

**Now:** every issue and every PR gets exactly one line in the whole file. An issue whose fix is in an open PR belongs to that PR's line, where the actionable verb is *merge*, not *start*.

Bands state the absence rather than going silently empty:

```markdown
## ❓ Needs triage

_None outstanding._ 2 untriaged issues exist (#17, #19) but both are already fixed and awaiting
merge, so they are listed once under 🔀 Open PRs against the PR that closes them.
```

An empty band and a band whose work is already done are different states, and the reader needs to tell them apart.

Added the check that catches it — every count must be `1`:

```console
$ grep -oE '/(issues|pull)/[0-9]+' TODO.md | sort | uniq -c | sort -rn
   1 /pull/994
   1 /pull/35
   ...
   1 /issues/19
   1 /issues/17
```

## 2. The mandated emphasis style fails the kit's own lint

The PR line format specified `*(ready | draft | conflicted)*`. The kit's own `.markdownlint.jsonc` sets MD049 to `underscore`. Following the spec produced a `TODO.md` that fails `npm run lint:md` **in the repo that generated it** — 4 MD049 errors on the first run:

```text
TODO.md:40:132 MD049/emphasis-style Emphasis style [Expected: underscore; Actual: asterisk]
```

Switched to `_(ready)_`.

## Also removed

The `Cross-reference both ways… annotate it in its own priority band as "— PR open: #<pr>"` paragraph, which mandated exactly the duplication the new rule forbids. Leaving it would have made the spec self-contradicting.

## Verification

`TODO.md` is regenerated in this PR under the corrected rules — every `/issues/` and `/pull/` reference appears exactly once, markdownlint clean on both changed files.

Ships downstream on the next kit sync: `.claude/commands/pstatus.md` is an `overwrite` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)